### PR TITLE
Use reset(array) instead of array[0]

### DIFF
--- a/src/twigextensions/ResponsiveImagesTwigExtension.php
+++ b/src/twigextensions/ResponsiveImagesTwigExtension.php
@@ -86,7 +86,7 @@ class ResponsiveImagesTwigExtension extends \Twig_Extension
 
     public function overrideHTML($html, array $options = array())
     {
-        $options = $options[0];
+        $options = reset($options);
         $options['sizes'] = $options['sizes'] ?? '100vw';
 
         $isRedactor = false;


### PR DESCRIPTION
If no options are passed in the filter, the default empty options array is used. Specifying an index on an empty array causes a PHP error.